### PR TITLE
dockerize + change devnet peers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:webupd8team/java && \
+    apt-get install -y software-properties-common apt-transport-https python-software-properties debconf-utils && \
+    apt-get update -y && \
+    echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections && \
+    apt-get install -y oracle-java8-installer && \
+    apt-get install -y maven pwgen nginx
+
+WORKDIR /app
+ADD . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  listener-ark:
+    build:
+      context: .
+    command: mvn spring-boot:run
+    environment:
+      APP_PORT: 9091
+      ARK_NETWORK: "devnet"
+      SERVICE_ARK_ADDRESS: "<your ARK address where fees will be sent to>"
+      SERVICE_MIN_ARK_STAKE: "0"
+      SERVICE_MIN_ARK_FEE: "1"
+      SERVICE_REQUIRE_AUTH: 0
+    volumes:
+      - listener-ark:/app
+    expose:
+      - "9091"
+    ports:
+      - "9091:9091"
+
+volumes:
+  listener-ark:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ serverInfo:
   description: "ACES Listener implementation for Ark"
   version: "1.0.0"
   websiteUrl: "https://arkaces.com"
-  
+
 #spring:
 #  datasource:
 #    url: "jdbc:h2:/tmp/ark-encoded-listener.db;DB_CLOSE_ON_EXIT=FALSE;AUTO_RECONNECT=TRUE"
@@ -13,30 +13,30 @@ serverInfo:
 #      ddl-auto: "create-drop"
 
 # Ark network config YML that listening will be performed against
-arkNetworkConfigPath: "ark_network_config/localnet.yml"
+arkNetworkConfigPath: "ark_network_config/${ARK_NETWORK}.yml"
 
 # Number of Transactions to scan through each execution cycle
 scanTransactionDepth: 500
 
 server:
-  port: 9091
+  port: ${APP_PORT}
 
 arkAuth:
-  requireAuth: true
+  requireAuth: ${SERVICE_REQUIRE_AUTH}
 
   # Ark Network to use for fetching and broadcasting ark auth transactions
-  arkNetworkConfigPath: "ark_network_config/localnet.yml"
+  arkNetworkConfigPath: "ark_network_config/${ARK_NETWORK}.yml"
 
   # The address that fees are sent to
-  serviceArkAddress: "ARNJJruY6RcuYCXcwWsu4bx9kyZtntqeAx"
+  serviceArkAddress: ${SERVICE_ARK_ADDRESS}
 
   # Amount of ARK required in your stake account address
-  minArkStake: "0"
+  minArkStake: ${SERVICE_MIN_ARK_STAKE}
 
   # Amount of ARK to charge payment account every 24 hours to keep
   # API key active
-  arkFee: "0"
+  arkFee: ${SERVICE_MIN_ARK_FEE}
 
 logging:
   level:
-    com.arkaces.aces_listener_ark.ArkEventListener: ERROR
+    com.arkaces.aces_listener_ark.ArkEventListener: INFO

--- a/src/main/resources/ark_network_config/devnet.yml
+++ b/src/main/resources/ark_network_config/devnet.yml
@@ -4,21 +4,9 @@ netHash: 578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23
 pubKeyHash: 0x52
 seedPeers:
   -
-    hostname: 167.114.29.52
-    port: 4002
-  -
-    hostname: 167.114.29.53
-    port: 4002
-  -
-    hostname: 167.114.29.55
+    hostname: 167.99.243.111
     port: 4002
 trustedPeers:
   -
-    hostname: 167.114.29.52
-    port: 4002
-  -
-    hostname: 167.114.29.53
-    port: 4002
-  -
-    hostname: 167.114.29.55
+    hostname: 167.99.243.111
     port: 4002


### PR DESCRIPTION
Similar to: https://github.com/ark-aces/aces-ark-ethereum-channel-service/pull/3

You can find and example of both changes:
- https://github.com/ark-aces/aces-ark-ethereum-channel-service/pull/3 
- https://github.com/ark-aces/aces-ark-ethereum-channel-service/pull/3)

... here: https://github.com/deadlock-delegate/aces-eth-ark-demo (I wanted to add ETH node as a container but it took way to long to build (even in light mode) and it took too much space (around 5gb). CPU and Memory were very high and I don't think it's reasonable to run the ETH node in a docker setup.